### PR TITLE
pass logger instance to ProviderBase constructor

### DIFF
--- a/lib/sqlProvider.js
+++ b/lib/sqlProvider.js
@@ -1,3 +1,4 @@
+var _ = require('lodash')
 var q = require('q')
 var ProviderBase = require('jsreport-core/lib/store/providerBase')
 var util = require('util')
@@ -5,7 +6,12 @@ var odataSql = require('odata-to-sql')
 var SqlCollection = require('./sqlCollection')
 
 var SqlProvider = module.exports = function (reporter, dialect, executeQuery) {
-  ProviderBase.call(this, reporter.documentStore.model, reporter.options)
+  ProviderBase.call(
+    this,
+    reporter.documentStore.model,
+    _.extend({}, reporter.options, { logger: reporter.logger })
+  )
+
   this.executeQuery = executeQuery
   this.dialect = dialect
 }
@@ -63,4 +69,3 @@ SqlProvider.prototype.odata = function (odataServer) {
       }).catch(cb)
     })
 }
-


### PR DESCRIPTION
since we are ensuring that `reporter.options.logger` is not the logger instance anymore, we must explicitly pass the logger instance.